### PR TITLE
Add clippy in continuous integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+
+script:
+  - rustup component add clippy-preview
+  - cargo build
+  - cargo clippy


### PR DESCRIPTION
Add clippy in the continuous integration but (now) do not fail if any warning is found.